### PR TITLE
feature: zigbee2mqtt/mosquitto support tls + auth

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.8.2
+version: 4.9.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto

--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -22,5 +22,7 @@ dependencies:
     version: 4.5.2
 annotations:
   artifacthub.io/changes: |-
+    - kind: added
+      description: Added support for tls encryption and password file.
     - kind: changed
       description: Upgraded `common` chart dependency to version 4.5.2

--- a/charts/stable/mosquitto/templates/common.yaml
+++ b/charts/stable/mosquitto/templates/common.yaml
@@ -13,5 +13,63 @@ volumeSpec:
 {{- end -}}
 {{- $_ := set .Values.persistence "mosquitto-config" (include "mosquitto.configVolume" . | fromYaml) -}}
 
+{{/* Append the password_secret as a volume */}}
+{{- define "mosquitto.passwordSecretVolume" -}}
+enabled: "true"
+mountPath: "/mosquitto/config/password-file.secret"
+subPath: "password-file.secret"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-password
+{{- end -}}
+{{- if .Values.persistence.passwordfile.enabled -}}
+{{- $_ := set .Values.persistence "passwordfile" (include "mosquitto.passwordSecretVolume" . | fromYaml) -}}
+{{- end -}}
+
+{{/* Append the certs files as volumes */}}
+{{- define "mosquitto.certsVolumes.serverCrt" -}}
+enabled: "true"
+mountPath: "/mosquitto/config/mqtt-server.crt"
+subPath: "mqtt-server.crt"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-mqtt-server-crt
+{{- end -}}
+{{- if .Values.persistence.ca.enabled  -}}
+{{- $_ := set .Values.persistence "server-crt" (include "mosquitto.certsVolumes.serverCrt" . | fromYaml) -}}
+{{- end -}}
+
+{{- define "mosquitto.certsVolumes.caCrt" -}}
+enabled: "true"
+mountPath: "/mosquitto/config/ca.crt"
+subPath: "ca.crt"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-ca-crt
+{{- end -}}
+{{- if .Values.persistence.ca.enabled  -}}
+{{- $_ := set .Values.persistence "ca" (include "mosquitto.certsVolumes.caCrt" . | fromYaml) -}}
+{{- end -}}
+
+{{- define "mosquitto.certsVolumes.serverKey" -}}
+enabled: "true"
+mountPath: "/mosquitto/config/mqtt-server.key"
+subPath: "mqtt-server.key"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-mqtt-server-key
+{{- end -}}
+{{- if .Values.persistence.ca.enabled  -}}
+{{- $_ := set .Values.persistence "server-key" (include "mosquitto.certsVolumes.serverKey" . | fromYaml) -}}
+{{- end -}}
+
 {{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/mosquitto/templates/configmap.yaml
+++ b/charts/stable/mosquitto/templates/configmap.yaml
@@ -25,3 +25,11 @@ data:
     {{- if .Values.persistence.configinc.enabled }}
     include_dir {{ .Values.persistence.configinc.mountPath }}
     {{- end }}
+    {{- if .Values.persistence.passwordfile.enabled }}
+    password_file /mosquitto/config/password-file.secret
+    {{- end }}
+    {{- if .Values.persistence.ca.enabled }}
+    cafile /mosquitto/config/ca.crt
+    keyfile /mosquitto/config/mqtt-server.key
+    certfile /mosquitto/config/mqtt-server.crt
+    {{- end }}

--- a/charts/stable/mosquitto/templates/secret.yaml
+++ b/charts/stable/mosquitto/templates/secret.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.persistence.passwordfile.enabled -}}
+{{- include "common.values.setup" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-password
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password-file.secret: |
+{{ .Values.auth.passwordfile | indent 4 }}
+{{ end }}
+
+
+{{- if .Values.persistence.ca.enabled -}}
+{{- include "common.values.setup" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-mqtt-server-crt
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  mqtt-server.crt: |
+{{ .Values.auth.mqttServerCrt | indent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-ca-crt
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca.crt: |
+{{ .Values.auth.caCrt | indent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-mqtt-server-key
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  mqtt-server.key: |
+{{ .Values.auth.mqttServerKey | indent 4 }}
+{{- end }}

--- a/charts/stable/zigbee2mqtt/Chart.yaml
+++ b/charts/stable/zigbee2mqtt/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 1.19.1
 description: Bridges events and allows you to control your Zigbee devices via MQTT
 name: zigbee2mqtt
-version: 9.4.2
+version: 9.5.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - zigbee

--- a/charts/stable/zigbee2mqtt/Chart.yaml
+++ b/charts/stable/zigbee2mqtt/Chart.yaml
@@ -24,5 +24,7 @@ dependencies:
     version: 4.5.2
 annotations:
   artifacthub.io/changes: |-
+    - kind: added
+      description: Support mutual tls.
     - kind: changed
       description: Upgraded `common` chart dependency to version 4.5.2

--- a/charts/stable/zigbee2mqtt/templates/common.yaml
+++ b/charts/stable/zigbee2mqtt/templates/common.yaml
@@ -13,5 +13,48 @@ volumeSpec:
 {{- end -}}
 {{- $_ := set .Values.persistence "zigbee2mqtt-settings" (include "zigbee2mqtt.settingsVolume" . | fromYaml) -}}
 
+
+{{- define "zigbee2mqtt.certsVolumes.clientKey" -}}
+enabled: "true"
+mountPath: "/certs/client.key"
+subPath: "client.key"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-client-key
+{{- end -}}
+{{- if .Values.tls.enabled  -}}
+{{- $_ := set .Values.persistence "clientkey" (include "zigbee2mqtt.certsVolumes.clientKey" . | fromYaml) -}}
+{{- end -}}
+
+{{- define "zigbee2mqtt.certsVolumes.clientCrt" -}}
+enabled: "true"
+mountPath: "/certs/client.crt"
+subPath: "client.crt"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-client-crt
+{{- end -}}
+{{- if .Values.tls.enabled  -}}
+{{- $_ := set .Values.persistence "clientcrt" (include "zigbee2mqtt.certsVolumes.clientCrt" . | fromYaml) -}}
+{{- end -}}
+
+{{- define "zigbee2mqtt.certsVolumes.caCrt" -}}
+enabled: "true"
+mountPath: "/certs/ca.crt"
+subPath: "ca.crt"
+type: "custom"
+volumeSpec:
+  secret:
+    defaultMode: 0555
+    secretName: {{ template "common.names.fullname" .  }}-ca-crt
+{{- end -}}
+{{- if .Values.tls.enabled  -}}
+{{- $_ := set .Values.persistence "cacrt" (include "zigbee2mqtt.certsVolumes.caCrt" . | fromYaml) -}}
+{{- end -}}
+
 {{/* Render the templates */}}
 {{ include "common.all" . }}

--- a/charts/stable/zigbee2mqtt/templates/secret.yaml
+++ b/charts/stable/zigbee2mqtt/templates/secret.yaml
@@ -1,0 +1,37 @@
+
+{{- if .Values.tls.enabled -}}
+{{- include "common.values.setup" . -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-client-crt
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  client.crt: |
+{{ .Values.tls.clientCrt | indent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-ca-crt
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca.crt: |
+{{ .Values.tls.caCrt | indent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-client-key
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  client.key: |
+{{ .Values.tls.clientKey | indent 4 }}
+{{- end }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
