### PR TITLE
Chore/mosquitto cleaner

### DIFF
--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.9.3
+version: 4.9.4
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -22,5 +22,5 @@ dependencies:
     version: 4.5.2
 annotations:
   artifacthub.io/changes: |-
-    - kind: fix
-      description: Changed the way secrets are stored to facilitate working with vaults.
+    - kind: chore
+      description: improved secrets management for tls.

--- a/charts/stable/mosquitto/Chart.yaml
+++ b/charts/stable/mosquitto/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: 2.0.14
 description: Eclipse Mosquitto - An open source MQTT broker
 name: mosquitto
-version: 4.9.2
+version: 4.9.3
 kubeVersion: ">=1.16.0-0"
 keywords:
   - mosquitto
@@ -23,4 +23,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: fix
-      description: Does not deploy.
+      description: Changed the way secrets are stored to facilitate working with vaults.

--- a/charts/stable/mosquitto/templates/common.yaml
+++ b/charts/stable/mosquitto/templates/common.yaml
@@ -16,13 +16,13 @@ volumeSpec:
 {{/* Append the password_secret as a volume */}}
 {{- define "mosquitto.passwordSecretVolume" -}}
 enabled: "true"
-mountPath: "/mosquitto/config/password-file.secret"
-subPath: "password-file.secret"
+mountPath: "/mosquitto/config/mosquitto-passwords"
+subPath: "mosquitto-passwords"
 type: "custom"
 volumeSpec:
   secret:
     defaultMode: 0555
-    secretName: {{ template "common.names.fullname" .  }}-password
+    secretName: {{ template "common.names.fullname" .  }}-secrets
 {{- end -}}
 {{- if .Values.persistence.passwordfile.enabled -}}
 {{- $_ := set .Values.persistence "passwordfile" (include "mosquitto.passwordSecretVolume" . | fromYaml) -}}
@@ -31,13 +31,13 @@ volumeSpec:
 {{/* Append the certs files as volumes */}}
 {{- define "mosquitto.certsVolumes.serverCrt" -}}
 enabled: "true"
-mountPath: "/mosquitto/config/mqtt-server.crt"
-subPath: "mqtt-server.crt"
+mountPath: "/mosquitto/config/mosquitto.crt"
+subPath: "mosquitto.crt"
 type: "custom"
 volumeSpec:
   secret:
     defaultMode: 0555
-    secretName: {{ template "common.names.fullname" .  }}-mqtt-server-crt
+    secretName: {{ template "common.names.fullname" .  }}-secrets
 {{- end -}}
 {{- if .Values.persistence.ca.enabled  -}}
 {{- $_ := set .Values.persistence "server-crt" (include "mosquitto.certsVolumes.serverCrt" . | fromYaml) -}}
@@ -59,13 +59,13 @@ volumeSpec:
 
 {{- define "mosquitto.certsVolumes.serverKey" -}}
 enabled: "true"
-mountPath: "/mosquitto/config/mqtt-server.key"
-subPath: "mqtt-server.key"
+mountPath: "/mosquitto/config/mosquitto.key"
+subPath: "mosquitto.key"
 type: "custom"
 volumeSpec:
   secret:
     defaultMode: 0555
-    secretName: {{ template "common.names.fullname" .  }}-mqtt-server-key
+    secretName: {{ template "common.names.fullname" .  }}-secrets
 {{- end -}}
 {{- if .Values.persistence.ca.enabled  -}}
 {{- $_ := set .Values.persistence "server-key" (include "mosquitto.certsVolumes.serverKey" . | fromYaml) -}}

--- a/charts/stable/mosquitto/templates/common.yaml
+++ b/charts/stable/mosquitto/templates/common.yaml
@@ -40,7 +40,7 @@ volumeSpec:
     secretName: {{ template "common.names.fullname" .  }}-secrets
 {{- end -}}
 {{- if .Values.persistence.ca.enabled  -}}
-{{- $_ := set .Values.persistence "server-crt" (include "mosquitto.certsVolumes.serverCrt" . | fromYaml) -}}
+{{- $_ := set .Values.persistence "crt" (include "mosquitto.certsVolumes.serverCrt" . | fromYaml) -}}
 {{- end -}}
 
 {{- define "mosquitto.certsVolumes.caCrt" -}}
@@ -68,7 +68,7 @@ volumeSpec:
     secretName: {{ template "common.names.fullname" .  }}-secrets
 {{- end -}}
 {{- if .Values.persistence.ca.enabled  -}}
-{{- $_ := set .Values.persistence "server-key" (include "mosquitto.certsVolumes.serverKey" . | fromYaml) -}}
+{{- $_ := set .Values.persistence "key" (include "mosquitto.certsVolumes.serverKey" . | fromYaml) -}}
 {{- end -}}
 
 {{/* Render the templates */}}

--- a/charts/stable/mosquitto/templates/configmap.yaml
+++ b/charts/stable/mosquitto/templates/configmap.yaml
@@ -30,10 +30,9 @@ data:
     {{- end }}
     {{- if .Values.persistence.ca.enabled }}
     cafile {{ .Values.persistence.ca.mountPath }}
+    require_certificate {{ .Values.auth.require_certificate }}
     {{- end }}
-    {{- if .Values.persistence.mqttServerKey.enabled }}
-    keyfile {{ .Values.persistence.mqttServerKey.mountPath }}
-    {{- end }}
-    {{- if .Values.persistence.mqttServerCrt.enabled }}
-    certfile {{ .Values.persistence.mqttServerCrt.mountPath }}
+    {{- if (or .Values.persistence.crt.enabled .Values.persistence.key.enabled) }}
+    keyfile {{ .Values.persistence.key.mountPath }}
+    certfile {{ .Values.persistence.crt.mountPath }}
     {{- end }}

--- a/charts/stable/mosquitto/templates/secret.yaml
+++ b/charts/stable/mosquitto/templates/secret.yaml
@@ -1,35 +1,3 @@
-{{- if and (hasKey .Values.auth "passwordfile") (not ( eq .Values.auth.passwordfile "")) .Values.persistence.passwordfile.enabled -}}
-{{- include "common.values.setup" . -}}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "common.names.fullname" . }}-password
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-type: Opaque
-data:
-  password-file.secret: |
-{{ .Values.auth.passwordfile | indent 4 }}
-{{ end }}
-
-
-{{- if and ( and (hasKey .Values.auth "mqttServerCrt") (not ( eq .Values.auth.mqttServerCrt ""))) .Values.persistence.ca.enabled -}}
-{{- include "common.values.setup" . -}}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "common.names.fullname" . }}-mqtt-server-crt
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-type: Opaque
-data:
-  mqtt-server.crt: |
-{{ .Values.auth.mqttServerCrt | indent 4 }}
-{{ end }}
-
-
 {{- if and ( and (hasKey .Values.auth "caCrt") (not ( eq .Values.auth.caCrt ""))) .Values.persistence.ca.enabled -}}
 ---
 apiVersion: v1
@@ -49,11 +17,15 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "common.names.fullname" . }}-mqtt-server-key
+  name: {{ template "common.names.fullname" . }}-mosquitto.key
   labels:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 data:
-  mqtt-server.key: |
+  mosquitto.key: |
 {{ .Values.auth.mqttServerKey | indent 4 }}
+  mosquitto.crt: |
+{{ .Values.auth.mqttServerCrt | indent 4 }}
+  mosquitto-passwords: |
+{{ .Values.auth.passwordfile | indent 4 }}
 {{- end }}

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -29,7 +29,25 @@ auth:
   # -- By enabling this, `allow_anonymous` gets set to `false` in the mosquitto config.
   enabled: false
 
-# -- By enabling this, authentication and access control settings will be controlled on a per-listener basis
+  # -- The following config allow to create secrets to provide the passwordfile or
+  # the certs needed for TLS encryption. Remember to enable the needed persistence
+  # to make this setting working.
+  # NB. The passwordfile and the caCrt can be provided as single entity while the
+  # other two must be provided together. Refer to mosquitto docs for more details.
+  #
+  # passwordfile: |
+  #   YWRtaW46JDckMTAxJGVXSy9zcHpJcjlnOFlTS2okN2grQ2pYbFg4Y3ArcmxlY1pm
+
+  # mqttServerKey: |
+  #    LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lH
+
+  # mqttServerCrt: |
+  #    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURSVENDQWkwQ0ZIa29jUCtv
+
+  # caCrt: |
+  #    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURjekNDQWx1Z0F3SUJBZ0lV
+
+  # -- By enabling this, authentication and access control settings will be controlled on a per-listener basis
 perListenerSettings: false
 
 # -- When enabled, this adds the `listener` option to the mosquitto config.
@@ -50,18 +68,22 @@ persistence:
     enabled: false
     mountPath: /mosquitto/configinc
 
+# -- Provide the data from the auth configuration or create a secret named
+# mosquitto-secrets containing the appropriate keys (eg. mosquitto-passwords).
   passwordfile:
     enabled: false
-    mountPath: /mosquitto/config/password-file.secret
-
-  ca:
-    enabled: false
-    mountPath: /mosquitto/config/ca.crt
+    mountPath: /mosquitto/config/mosquitto-passwords
 
   mqttServerKey:
     enabled: false
-    mountPath: /mosquitto/config/mqtt-server.key
+    mountPath: /mosquitto/config/mosquitto.key
 
   mqttServerCrt:
     enabled: false
-    mountPath: /mosquitto/config/mqtt-server.crt
+    mountPath: /mosquitto/config/mosquitto.crt
+
+# -- If the CA is not provided from the auth config, a secret named mosquitto-ca-crt is expected
+# containing the CA cert to authenticate clients in the key ca.crt.
+  ca:
+    enabled: false
+    mountPath: /mosquitto/config/ca.crt

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -29,6 +29,10 @@ auth:
   # -- By enabling this, `allow_anonymous` gets set to `false` in the mosquitto config.
   enabled: false
 
+  # -- Allows only client presenting a valid certificate.
+  require_certificate: false
+
+
   # -- The following config allow to create secrets to provide the passwordfile or
   # the certs needed for TLS encryption. Remember to enable the needed persistence
   # to make this setting working.
@@ -74,11 +78,11 @@ persistence:
     enabled: false
     mountPath: /mosquitto/config/mosquitto-passwords
 
-  mqttServerKey:
+  key:
     enabled: false
     mountPath: /mosquitto/config/mosquitto.key
 
-  mqttServerCrt:
+  crt:
     enabled: false
     mountPath: /mosquitto/config/mosquitto.crt
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
